### PR TITLE
bulk endpoint, API auth, rate limiting, pagination, logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ Optional environment variables (pass via `docker run --env`):
 | `ALLOW_ORIGINS` | `*` | Comma-separated allowed CORS origins |
 ## Usage
 All API Endpoints described on [localhost:8000/docs](localhost:8000/docs):
-- */* - homepage
-- */get_info/{cve_id}* - Main function: return info from vulnx (old cvemap) and determine priority
-- */reget_info/{cve_id}* - Return info from vulnx (old cvemap) and priority (use when result outdated)
-- */all_results* - Return all results with full info (without priorities)
-- *DELETE /results* - Remove all results (use when results outdated)
+- *GET /* - homepage / health check
+- *GET /v1/get_info/{cve_id}* - Main function: return info from vulnx (old cvemap) and determine priority
+- *GET /v1/reget_info/{cve_id}* - Force refresh: invalidate cache and re-fetch from vulnx
+- *GET /v1/all_results* - Return all cached results with full raw info (without priorities)
+- *DELETE /v1/results* - Remove all cached results (use when results outdated)
 ## Roadmap
 ### Done
 - [x] *New flow*: Publish to ghcr.io, update start instructions
@@ -54,5 +54,5 @@ All API Endpoints described on [localhost:8000/docs](localhost:8000/docs):
 - [ ] *Bulk endpoint*: POST /get_info with array of CVE IDs for batch processing
 - [ ] *API auth*: Optional X-API-Key header (CVE_PAAS_API_KEY env) to protect quota
 - [ ] *Rate limiting*: Per-client request throttling
-- [ ] *API versioning*: /v1/ prefix for stable contract with consumers
+- [x] *API versioning*: /v1/ prefix for stable contract with consumers
 - [ ] *Pydantic response models*: Typed response schemas for OpenAPI codegen

--- a/README.md
+++ b/README.md
@@ -26,7 +26,14 @@ You need to install docker itself and then do next commands:
 ```
 For the first start you must write API key from [ProjectDiscovery](https://cloud.projectdiscovery.io/) (you need to be registered).
 ## Configuration
-Optional environment variables (pass via `docker run --env`):
+Environment variables (pass via `docker run --env`):
+
+**Required**
+| Variable | Description |
+| -------- | ----------- |
+| `PDCP_API_KEY` | API key from [ProjectDiscovery Cloud Platform](https://cloud.projectdiscovery.io/) — required by vulnx to fetch CVE data |
+
+**Optional**
 | Variable | Default | Description |
 | -------- | ------- | ----------- |
 | `CVSS_THRESHOLD` | `6.0` | CVSS score boundary for High/Medium/Low |
@@ -37,6 +44,7 @@ Optional environment variables (pass via `docker run --env`):
 All API Endpoints described on [localhost:8000/docs](localhost:8000/docs):
 - *GET /* - homepage / health check
 - *GET /v1/get_info/{cve_id}* - Main function: return info from vulnx (old cvemap) and determine priority
+- *POST /v1/cve* - Bulk lookup: accepts `{"cve_ids": ["CVE-YYYY-NNNNN", ...]}` (1–50 IDs), returns map of CVE ID → priority result
 - *GET /v1/reget_info/{cve_id}* - Force refresh: invalidate cache and re-fetch from vulnx
 - *GET /v1/all_results* - Return all cached results with full raw info (without priorities)
 - *DELETE /v1/results* - Remove all cached results (use when results outdated)
@@ -52,7 +60,7 @@ All API Endpoints described on [localhost:8000/docs](localhost:8000/docs):
 
 ### Planned
 - [x] *Cache TTL*: Auto-expire cached results after configurable period (CACHE_TTL_HOURS)
-- [ ] *Bulk endpoint*: POST /get_info with array of CVE IDs for batch processing
+- [x] *Bulk endpoint*: POST /v1/cve with array of CVE IDs for batch processing (1–50 IDs, cache-aware)
 - [ ] *API auth*: Optional X-API-Key header (CVE_PAAS_API_KEY env) to protect quota
 - [ ] *Rate limiting*: Per-client request throttling
 - [x] *API versioning*: /v1/ prefix for stable contract with consumers

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Environment variables (pass via `docker run --env`):
 | `EPSS_THRESHOLD` | `0.2` | EPSS score boundary for High/Low |
 | `ALLOW_ORIGINS` | `*` | Comma-separated allowed CORS origins |
 | `CACHE_TTL_HOURS` | `0` | Hours before cached result expires and re-fetches (0 = never expire) |
+| `CVE_PAAS_API_KEY` | _(not set)_ | If set, all `/v1/` requests must include `X-API-Key: <value>` header — returns 401 otherwise |
+| `RATE_LIMIT` | `0` | Max requests per minute per client IP across all endpoints (0 = disabled) — returns 429 when exceeded |
 ## Usage
 All API Endpoints described on [localhost:8000/docs](localhost:8000/docs):
 - *GET /* - homepage / health check
@@ -61,7 +63,7 @@ All API Endpoints described on [localhost:8000/docs](localhost:8000/docs):
 ### Planned
 - [x] *Cache TTL*: Auto-expire cached results after configurable period (CACHE_TTL_HOURS)
 - [x] *Bulk endpoint*: POST /v1/cve with array of CVE IDs for batch processing (1–50 IDs, cache-aware)
-- [ ] *API auth*: Optional X-API-Key header (CVE_PAAS_API_KEY env) to protect quota
-- [ ] *Rate limiting*: Per-client request throttling
+- [x] *API auth*: Optional X-API-Key header (CVE_PAAS_API_KEY env) to protect quota
+- [x] *Rate limiting*: Per-client request throttling (RATE_LIMIT requests/minute, sliding window)
 - [x] *API versioning*: /v1/ prefix for stable contract with consumers
 - [ ] *Pydantic response models*: Typed response schemas for OpenAPI codegen

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ All API Endpoints described on [localhost:8000/docs](localhost:8000/docs):
 - *GET /v1/get_info/{cve_id}* - Main function: return info from vulnx (old cvemap) and determine priority
 - *POST /v1/cve* - Bulk lookup: accepts `{"cve_ids": ["CVE-YYYY-NNNNN", ...]}` (1–50 IDs), returns map of CVE ID → priority result
 - *GET /v1/reget_info/{cve_id}* - Force refresh: invalidate cache and re-fetch from vulnx
-- *GET /v1/all_results* - Return all cached results with full raw info (without priorities)
+- *GET /v1/all_results* - Return cached results with full raw info (without priorities); supports `?offset=0&limit=100` (max 1000)
 - *DELETE /v1/results* - Remove all cached results (use when results outdated)
 ## Roadmap
 ### Done

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Optional environment variables (pass via `docker run --env`):
 | `CVSS_THRESHOLD` | `6.0` | CVSS score boundary for High/Medium/Low |
 | `EPSS_THRESHOLD` | `0.2` | EPSS score boundary for High/Low |
 | `ALLOW_ORIGINS` | `*` | Comma-separated allowed CORS origins |
+| `CACHE_TTL_HOURS` | `0` | Hours before cached result expires and re-fetches (0 = never expire) |
 ## Usage
 All API Endpoints described on [localhost:8000/docs](localhost:8000/docs):
 - *GET /* - homepage / health check
@@ -50,7 +51,7 @@ All API Endpoints described on [localhost:8000/docs](localhost:8000/docs):
 - [x] *Tests*: Pytest suite with CI workflow
 
 ### Planned
-- [ ] *Cache TTL*: Auto-expire cached results after configurable period (CACHE_TTL_HOURS)
+- [x] *Cache TTL*: Auto-expire cached results after configurable period (CACHE_TTL_HOURS)
 - [ ] *Bulk endpoint*: POST /get_info with array of CVE IDs for batch processing
 - [ ] *API auth*: Optional X-API-Key header (CVE_PAAS_API_KEY env) to protect quota
 - [ ] *Rate limiting*: Per-client request throttling

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import json
 import os
 import subprocess
 from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
 from typing import Annotated
 
 import aiosqlite
@@ -35,15 +36,20 @@ class StatusResponse(BaseModel):
 origins = os.getenv("ALLOW_ORIGINS", "*").split(",")
 cvss_threshold = float(os.getenv("CVSS_THRESHOLD", "6.0"))
 epss_threshold = float(os.getenv("EPSS_THRESHOLD", "0.2"))
+cache_ttl_hours = float(os.getenv("CACHE_TTL_HOURS", "0"))  # 0 = disabled
 
 DB_PATH = "cve_cache.db"
-SCHEMA = "CREATE TABLE IF NOT EXISTS results (cve_id TEXT PRIMARY KEY, data TEXT NOT NULL)"
+SCHEMA = "CREATE TABLE IF NOT EXISTS results (cve_id TEXT PRIMARY KEY, data TEXT NOT NULL, cached_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)"
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     async with aiosqlite.connect(DB_PATH) as db:
         await db.execute(SCHEMA)
+        try:
+            await db.execute("ALTER TABLE results ADD COLUMN cached_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP")
+        except aiosqlite.OperationalError:
+            pass  # column already exists
         await db.commit()
     yield
 
@@ -91,8 +97,12 @@ async def get_info(cve_id: Annotated[str, Path(
     """ Fetch CVE data via vulnx (old cvemap), cache it locally, and return priority with details. """
     try:
         async with aiosqlite.connect(DB_PATH) as db:
-            async with db.execute("SELECT data FROM results WHERE cve_id = ?", (cve_id,)) as cursor:
+            async with db.execute("SELECT data, cached_at FROM results WHERE cve_id = ?", (cve_id,)) as cursor:
                 row = await cursor.fetchone()
+            if row is not None and cache_ttl_hours > 0:
+                cached_at = datetime.strptime(row[1], "%Y-%m-%d %H:%M:%S").replace(tzinfo=timezone.utc)
+                if datetime.now(timezone.utc) - cached_at > timedelta(hours=cache_ttl_hours):
+                    row = None
             if row is None:
                 output = subprocess.run(["vulnx", "id", cve_id, "--json"], capture_output=True, check=False)
                 try:
@@ -100,7 +110,7 @@ async def get_info(cve_id: Annotated[str, Path(
                 except json.JSONDecodeError as e:
                     return JSONResponse({"error": str(e)}, status_code=502)
                 await db.execute(
-                    "INSERT OR REPLACE INTO results (cve_id, data) VALUES (?, ?)",
+                    "INSERT OR REPLACE INTO results (cve_id, data, cached_at) VALUES (?, ?, CURRENT_TIMESTAMP)",
                     (cve_id, json.dumps(raw)),
                 )
                 await db.commit()

--- a/main.py
+++ b/main.py
@@ -1,11 +1,13 @@
 """ CVE-PaaS FastAPI backend """
 
+import asyncio
 import json
+import logging
 import os
 import subprocess
 import time
 from collections import defaultdict
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from datetime import datetime, timedelta, timezone
 from typing import Annotated, Any, Literal, Optional
 
@@ -14,6 +16,13 @@ from fastapi import APIRouter, Depends, FastAPI, Header, HTTPException, Path, Re
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 from starlette.responses import JSONResponse, RedirectResponse
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
 
 CVE_PATTERN = r"^CVE-\d{4}-\d{4,7}$"
 
@@ -103,7 +112,19 @@ def _compute_priority(res: dict) -> dict:
 
 async def verify_api_key(x_api_key: Annotated[str | None, Header()] = None):
     if api_key_secret is not None and x_api_key != api_key_secret:
+        logger.warning("Rejected request: invalid or missing X-API-Key")
         raise HTTPException(status_code=401, detail="Invalid or missing X-API-Key")
+
+
+async def _cleanup_rate_counters():
+    while True:
+        await asyncio.sleep(300)
+        cutoff = time.time() - 60.0
+        stale = [ip for ip, times in _rate_counters.items() if not times or max(times) < cutoff]
+        for ip in stale:
+            del _rate_counters[ip]
+        if stale:
+            logger.debug("Rate counter cleanup: evicted %d stale IPs", len(stale))
 
 
 @asynccontextmanager
@@ -115,7 +136,11 @@ async def lifespan(app: FastAPI):
         except aiosqlite.OperationalError:
             pass  # column already exists
         await db.commit()
+    cleanup_task = asyncio.create_task(_cleanup_rate_counters())
     yield
+    cleanup_task.cancel()
+    with suppress(asyncio.CancelledError):
+        await cleanup_task
 
 
 app = FastAPI(
@@ -141,6 +166,7 @@ async def rate_limit_middleware(request: Request, call_next):
     window_start = now - 60.0
     _rate_counters[client_ip] = [t for t in _rate_counters[client_ip] if t > window_start]
     if len(_rate_counters[client_ip]) >= rate_limit:
+        logger.warning("Rate limit exceeded for %s on %s %s", client_ip, request.method, request.url.path)
         return JSONResponse({"error": "Rate limit exceeded"}, status_code=429)
     _rate_counters[client_ip].append(now)
     return await call_next(request)
@@ -163,7 +189,9 @@ async def remove_results():
             await db.execute("DELETE FROM results")
             await db.commit()
     except aiosqlite.Error as e:
+        logger.error("DB error clearing results: %s", e)
         return JSONResponse({"error": str(e)}, status_code=500)
+    logger.info("All cached results cleared")
     return {"Status": "OK", "Endpoint": "remove_results"}
 
 
@@ -179,12 +207,15 @@ async def get_info(cve_id: Annotated[str, Path(
             async with db.execute("SELECT data, cached_at FROM results WHERE cve_id = ?", (cve_id,)) as cursor:
                 row = await cursor.fetchone()
             if row is not None and _is_stale(row[1]):
+                logger.info("Cache stale for %s, re-fetching", cve_id)
                 row = None
             if row is None:
+                logger.info("Cache miss for %s, calling vulnx", cve_id)
                 output = subprocess.run(["vulnx", "id", cve_id, "--json"], capture_output=True, check=False)
                 try:
                     raw = json.loads(output.stdout.decode())
                 except json.JSONDecodeError as e:
+                    logger.error("vulnx returned invalid JSON for %s: %s", cve_id, e)
                     return JSONResponse({"error": str(e)}, status_code=502)
                 await db.execute(
                     "INSERT OR REPLACE INTO results (cve_id, data, cached_at) VALUES (?, ?, CURRENT_TIMESTAMP)",
@@ -193,8 +224,10 @@ async def get_info(cve_id: Annotated[str, Path(
                 await db.commit()
                 res = raw
             else:
+                logger.info("Cache hit for %s", cve_id)
                 res = json.loads(row[0])
     except aiosqlite.Error as e:
+        logger.error("DB error for %s: %s", cve_id, e)
         return JSONResponse({"error": str(e)}, status_code=500)
     return _compute_priority(res)
 
@@ -218,8 +251,10 @@ async def bulk_get_info(body: BulkRequest):
                 cve_id for cve_id in unique_ids
                 if cve_id not in cached or _is_stale(cached[cve_id][1])
             ]
+            logger.info("Bulk lookup: %d total, %d cached, %d missing", len(unique_ids), len(unique_ids) - len(missing), len(missing))
 
             if missing:
+                logger.info("Calling vulnx for %d CVEs: %s", len(missing), ", ".join(missing))
                 output = subprocess.run(
                     ["vulnx", "id", ",".join(missing), "--json"],
                     capture_output=True, check=False,
@@ -227,6 +262,7 @@ async def bulk_get_info(body: BulkRequest):
                 try:
                     raw = json.loads(output.stdout.decode())
                 except json.JSONDecodeError as e:
+                    logger.error("vulnx returned invalid JSON for bulk request: %s", e)
                     return JSONResponse({"error": str(e)}, status_code=502)
 
                 items = raw if isinstance(raw, list) else [raw]

--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ from contextlib import asynccontextmanager
 from typing import Annotated
 
 import aiosqlite
-from fastapi import FastAPI, Path
+from fastapi import APIRouter, FastAPI, Path
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.responses import JSONResponse, RedirectResponse
 
@@ -40,6 +40,8 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+v1 = APIRouter(prefix="/v1")
+
 
 @app.get("/", tags=["General"], summary="Health check")
 async def homepage():
@@ -50,7 +52,7 @@ async def homepage():
     })
 
 
-@app.delete("/results", tags=["Results"], summary="Delete all cached results")
+@v1.delete("/results", tags=["Results"], summary="Delete all cached results")
 async def remove_results():
     """ Remove all cached CVE results. Use when data is outdated. """
     try:
@@ -65,7 +67,7 @@ async def remove_results():
     })
 
 
-@app.get("/get_info/{cve_id}", tags=["CVE"], summary="Get CVE priority and details")
+@v1.get("/get_info/{cve_id}", tags=["CVE"], summary="Get CVE priority and details")
 async def get_info(cve_id: Annotated[str, Path(
     pattern=r"^CVE-\d{4}-\d{4,7}$",
     examples=["CVE-2024-1337"],
@@ -128,7 +130,7 @@ async def get_info(cve_id: Annotated[str, Path(
     })
 
 
-@app.get("/all_results", tags=["Results"], summary="Get all cached CVE results")
+@v1.get("/all_results", tags=["Results"], summary="Get all cached CVE results")
 async def all_results():
     """ Return all locally cached CVE entries with full raw data (without priorities). """
     res = {}
@@ -146,7 +148,7 @@ async def all_results():
     return JSONResponse(res)
 
 
-@app.get("/reget_info/{cve_id}", tags=["CVE"], summary="Force refresh CVE data")
+@v1.get("/reget_info/{cve_id}", tags=["CVE"], summary="Force refresh CVE data")
 async def reget_info(cve_id: Annotated[str, Path(
     pattern=r"^CVE-\d{4}-\d{4,7}$",
     examples=["CVE-2024-1337"],
@@ -159,4 +161,7 @@ async def reget_info(cve_id: Annotated[str, Path(
             await db.commit()
     except aiosqlite.Error as e:
         return JSONResponse({"error": str(e)}, status_code=500)
-    return RedirectResponse(f"/get_info/{cve_id}")
+    return RedirectResponse(f"/v1/get_info/{cve_id}")
+
+
+app.include_router(v1)

--- a/main.py
+++ b/main.py
@@ -5,14 +5,15 @@ import os
 import subprocess
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
-from typing import Annotated
+from typing import Annotated, Any, Literal, Optional
 
 import aiosqlite
 from fastapi import APIRouter, FastAPI, Path
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from starlette.responses import JSONResponse, RedirectResponse
-from typing import Any, Literal, Optional
+
+CVE_PATTERN = r"^CVE-\d{4}-\d{4,7}$"
 
 
 class CVEDetails(BaseModel):
@@ -33,6 +34,14 @@ class StatusResponse(BaseModel):
     Status: str
     Endpoint: str
 
+
+class BulkRequest(BaseModel):
+    cve_ids: Annotated[
+        list[Annotated[str, Field(pattern=CVE_PATTERN)]],
+        Field(min_length=1, max_length=50, description="1–50 CVE identifiers"),
+    ]
+
+
 origins = os.getenv("ALLOW_ORIGINS", "*").split(",")
 cvss_threshold = float(os.getenv("CVSS_THRESHOLD", "6.0"))
 epss_threshold = float(os.getenv("EPSS_THRESHOLD", "0.2"))
@@ -40,6 +49,50 @@ cache_ttl_hours = float(os.getenv("CACHE_TTL_HOURS", "0"))  # 0 = disabled
 
 DB_PATH = "cve_cache.db"
 SCHEMA = "CREATE TABLE IF NOT EXISTS results (cve_id TEXT PRIMARY KEY, data TEXT NOT NULL, cached_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)"
+
+
+def _is_stale(cached_at_str: str) -> bool:
+    if cache_ttl_hours <= 0:
+        return False
+    cached_at = datetime.strptime(cached_at_str, "%Y-%m-%d %H:%M:%S").replace(tzinfo=timezone.utc)
+    return datetime.now(timezone.utc) - cached_at > timedelta(hours=cache_ttl_hours)
+
+
+def _compute_priority(res: dict) -> dict:
+    cvss_score = res.get("cvss_score")
+    epss_score = (res.get("epss") or {}).get("epss_score")
+    is_template = res.get("is_template")
+    is_exploited = res.get("is_exploited")
+    is_poc = res.get("is_poc")
+    links = None
+    if is_exploited or is_template or is_poc:
+        priority = "Critical"
+        links = {
+            "POC": res.get("poc"),
+            "Nuclei templates": res.get("nuclei_templates"),
+            "KEV": res.get("kev"),
+        }
+    elif not isinstance(cvss_score, (int, float)) or not isinstance(epss_score, (int, float)):
+        priority = "Undefined"
+    elif cvss_score > cvss_threshold and epss_score > epss_threshold:
+        priority = "High"
+    elif cvss_score > cvss_threshold:
+        priority = "Medium"
+    elif epss_score > epss_threshold:
+        priority = "Low"
+    else:
+        priority = "Info"
+    return {
+        "Priority": priority,
+        "Details": {
+            "CVSS": cvss_score,
+            "EPSS": epss_score,
+            "is_template": is_template,
+            "is_exploited": is_exploited,
+            "is_poc": is_poc,
+            "Links": links,
+        },
+    }
 
 
 @asynccontextmanager
@@ -90,7 +143,7 @@ async def remove_results():
 
 @v1.get("/get_info/{cve_id}", tags=["CVE"], summary="Get CVE priority and details", response_model=CVEResponse)
 async def get_info(cve_id: Annotated[str, Path(
-    pattern=r"^CVE-\d{4}-\d{4,7}$",
+    pattern=CVE_PATTERN,
     examples=["CVE-2024-1337"],
     description="CVE identifier in format CVE-YYYY-NNNNN",
 )]):
@@ -99,10 +152,8 @@ async def get_info(cve_id: Annotated[str, Path(
         async with aiosqlite.connect(DB_PATH) as db:
             async with db.execute("SELECT data, cached_at FROM results WHERE cve_id = ?", (cve_id,)) as cursor:
                 row = await cursor.fetchone()
-            if row is not None and cache_ttl_hours > 0:
-                cached_at = datetime.strptime(row[1], "%Y-%m-%d %H:%M:%S").replace(tzinfo=timezone.utc)
-                if datetime.now(timezone.utc) - cached_at > timedelta(hours=cache_ttl_hours):
-                    row = None
+            if row is not None and _is_stale(row[1]):
+                row = None
             if row is None:
                 output = subprocess.run(["vulnx", "id", cve_id, "--json"], capture_output=True, check=False)
                 try:
@@ -119,40 +170,63 @@ async def get_info(cve_id: Annotated[str, Path(
                 res = json.loads(row[0])
     except aiosqlite.Error as e:
         return JSONResponse({"error": str(e)}, status_code=500)
-    cvss_score = res.get("cvss_score")
-    epss_score = (res.get("epss") or {}).get("epss_score")
-    is_template = res.get("is_template")
-    is_exploited = res.get("is_exploited")
-    is_poc = res.get("is_poc")
-    links = None
-    if is_exploited or is_template or is_poc:
-        priority = "Critical"
-        links = {
-            "POC" : res.get("poc"),
-            "Nuclei templates": res.get("nuclei_templates"),
-            "KEV": res.get("kev")
-        }
-    elif not isinstance(cvss_score, (int, float)) or not isinstance(epss_score, (int, float)):
-        priority = "Undefined"
-    elif cvss_score > cvss_threshold and epss_score > epss_threshold:
-        priority = "High"
-    elif cvss_score > cvss_threshold:
-        priority = "Medium"
-    elif epss_score > epss_threshold:
-        priority = "Low"
-    else:
-        priority = "Info"
-    return {
-        "Priority": priority,
-        "Details": {
-            "CVSS": cvss_score,
-            "EPSS": epss_score,
-            "is_template": is_template,
-            "is_exploited": is_exploited,
-            "is_poc": is_poc,
-            "Links": links,
-        },
-    }
+    return _compute_priority(res)
+
+
+@v1.post("/cve", tags=["CVE"], summary="Get priority for multiple CVEs (bulk)", response_model=None)
+async def bulk_get_info(body: BulkRequest):
+    """ Fetch CVE data for up to 50 CVEs. Cache-aware: calls vulnx only for missing or stale entries. """
+    unique_ids = list(dict.fromkeys(body.cve_ids))  # deduplicate, preserve order
+    results: dict[str, Any] = {}
+
+    try:
+        async with aiosqlite.connect(DB_PATH) as db:
+            placeholders = ",".join("?" * len(unique_ids))
+            async with db.execute(
+                f"SELECT cve_id, data, cached_at FROM results WHERE cve_id IN ({placeholders})",
+                unique_ids,
+            ) as cursor:
+                cached = {row[0]: (row[1], row[2]) for row in await cursor.fetchall()}
+
+            missing = [
+                cve_id for cve_id in unique_ids
+                if cve_id not in cached or _is_stale(cached[cve_id][1])
+            ]
+
+            if missing:
+                output = subprocess.run(
+                    ["vulnx", "id", ",".join(missing), "--json"],
+                    capture_output=True, check=False,
+                )
+                try:
+                    raw = json.loads(output.stdout.decode())
+                except json.JSONDecodeError as e:
+                    return JSONResponse({"error": str(e)}, status_code=502)
+
+                items = raw if isinstance(raw, list) else [raw]
+                for item in items:
+                    item_id = item.get("cve_id")
+                    if item_id:
+                        await db.execute(
+                            "INSERT OR REPLACE INTO results (cve_id, data, cached_at) VALUES (?, ?, CURRENT_TIMESTAMP)",
+                            (item_id, json.dumps(item)),
+                        )
+                        cached[item_id] = (json.dumps(item), None)
+                await db.commit()
+
+    except aiosqlite.Error as e:
+        return JSONResponse({"error": str(e)}, status_code=500)
+
+    for cve_id in unique_ids:
+        if cve_id not in cached:
+            results[cve_id] = {"error": "not found in vulnx response"}
+            continue
+        try:
+            results[cve_id] = _compute_priority(json.loads(cached[cve_id][0]))
+        except (json.JSONDecodeError, Exception) as e:
+            results[cve_id] = {"error": str(e)}
+
+    return results
 
 
 @v1.get("/all_results", tags=["Results"], summary="Get all cached CVE results", response_model=None)
@@ -175,7 +249,7 @@ async def all_results():
 
 @v1.get("/reget_info/{cve_id}", tags=["CVE"], summary="Force refresh CVE data")
 async def reget_info(cve_id: Annotated[str, Path(
-    pattern=r"^CVE-\d{4}-\d{4,7}$",
+    pattern=CVE_PATTERN,
     examples=["CVE-2024-1337"],
     description="CVE identifier in format CVE-YYYY-NNNNN",
 )]):

--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Annotated, Any, Literal, Optional
 
 import aiosqlite
-from fastapi import APIRouter, Depends, FastAPI, Header, HTTPException, Path, Request
+from fastapi import APIRouter, Depends, FastAPI, Header, HTTPException, Path, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 from starlette.responses import JSONResponse, RedirectResponse
@@ -51,6 +51,13 @@ class BulkRequest(BaseModel):
         list[Annotated[str, Field(pattern=CVE_PATTERN)]],
         Field(min_length=1, max_length=50, description="1–50 CVE identifiers"),
     ]
+
+
+class AllResultsResponse(BaseModel):
+    total: int
+    offset: int
+    limit: int
+    results: dict[str, Any]
 
 
 origins = os.getenv("ALLOW_ORIGINS", "*").split(",")
@@ -291,22 +298,28 @@ async def bulk_get_info(body: BulkRequest):
     return results
 
 
-@v1.get("/all_results", tags=["Results"], summary="Get all cached CVE results", response_model=None)
-async def all_results():
-    """ Return all locally cached CVE entries with full raw data (without priorities). """
-    res = {}
+@v1.get("/all_results", tags=["Results"], summary="Get all cached CVE results", response_model=AllResultsResponse)
+async def all_results(
+    offset: Annotated[int, Query(ge=0, description="Number of results to skip")] = 0,
+    limit: Annotated[int, Query(ge=1, le=1000, description="Max results to return")] = 100,
+):
+    """ Return cached CVE entries with full raw data (without priorities). Supports pagination via offset/limit. """
     try:
         async with aiosqlite.connect(DB_PATH) as db:
-            async with db.execute("SELECT cve_id, data FROM results") as cursor:
+            async with db.execute("SELECT COUNT(*) FROM results") as cursor:
+                total = (await cursor.fetchone())[0]
+            async with db.execute("SELECT cve_id, data FROM results LIMIT ? OFFSET ?", (limit, offset)) as cursor:
                 rows = await cursor.fetchall()
-        for cve_id, data in rows:
-            try:
-                res[cve_id] = json.loads(data)
-            except json.JSONDecodeError as e:
-                res[cve_id] = {"error": str(e)}
     except aiosqlite.Error as e:
+        logger.error("DB error fetching all results: %s", e)
         return JSONResponse({"error": str(e)}, status_code=500)
-    return JSONResponse(res)
+    results = {}
+    for cve_id, data in rows:
+        try:
+            results[cve_id] = json.loads(data)
+        except json.JSONDecodeError as e:
+            results[cve_id] = {"error": str(e)}
+    return {"total": total, "offset": offset, "limit": limit, "results": results}
 
 
 @v1.get("/reget_info/{cve_id}", tags=["CVE"], summary="Force refresh CVE data")

--- a/main.py
+++ b/main.py
@@ -9,7 +9,28 @@ from typing import Annotated
 import aiosqlite
 from fastapi import APIRouter, FastAPI, Path
 from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
 from starlette.responses import JSONResponse, RedirectResponse
+from typing import Any, Literal, Optional
+
+
+class CVEDetails(BaseModel):
+    CVSS: Optional[float] = None
+    EPSS: Optional[float] = None
+    is_template: Optional[bool] = None
+    is_exploited: Optional[bool] = None
+    is_poc: Optional[bool] = None
+    Links: Optional[dict[str, Any]] = None
+
+
+class CVEResponse(BaseModel):
+    Priority: Literal["Critical", "High", "Medium", "Low", "Info", "Undefined"]
+    Details: CVEDetails
+
+
+class StatusResponse(BaseModel):
+    Status: str
+    Endpoint: str
 
 origins = os.getenv("ALLOW_ORIGINS", "*").split(",")
 cvss_threshold = float(os.getenv("CVSS_THRESHOLD", "6.0"))
@@ -43,16 +64,13 @@ app.add_middleware(
 v1 = APIRouter(prefix="/v1")
 
 
-@app.get("/", tags=["General"], summary="Health check")
+@app.get("/", tags=["General"], summary="Health check", response_model=StatusResponse)
 async def homepage():
     """ Return default homepage """
-    return JSONResponse({
-        "Status": "OK",
-        "Endpoint": "homepage"
-    })
+    return {"Status": "OK", "Endpoint": "homepage"}
 
 
-@v1.delete("/results", tags=["Results"], summary="Delete all cached results")
+@v1.delete("/results", tags=["Results"], summary="Delete all cached results", response_model=StatusResponse)
 async def remove_results():
     """ Remove all cached CVE results. Use when data is outdated. """
     try:
@@ -61,13 +79,10 @@ async def remove_results():
             await db.commit()
     except aiosqlite.Error as e:
         return JSONResponse({"error": str(e)}, status_code=500)
-    return JSONResponse({
-        "Status": "OK",
-        "Endpoint": "remove_results"
-    })
+    return {"Status": "OK", "Endpoint": "remove_results"}
 
 
-@v1.get("/get_info/{cve_id}", tags=["CVE"], summary="Get CVE priority and details")
+@v1.get("/get_info/{cve_id}", tags=["CVE"], summary="Get CVE priority and details", response_model=CVEResponse)
 async def get_info(cve_id: Annotated[str, Path(
     pattern=r"^CVE-\d{4}-\d{4,7}$",
     examples=["CVE-2024-1337"],
@@ -117,7 +132,7 @@ async def get_info(cve_id: Annotated[str, Path(
         priority = "Low"
     else:
         priority = "Info"
-    return JSONResponse({
+    return {
         "Priority": priority,
         "Details": {
             "CVSS": cvss_score,
@@ -125,12 +140,12 @@ async def get_info(cve_id: Annotated[str, Path(
             "is_template": is_template,
             "is_exploited": is_exploited,
             "is_poc": is_poc,
-            "Links": links
-        }
-    })
+            "Links": links,
+        },
+    }
 
 
-@v1.get("/all_results", tags=["Results"], summary="Get all cached CVE results")
+@v1.get("/all_results", tags=["Results"], summary="Get all cached CVE results", response_model=None)
 async def all_results():
     """ Return all locally cached CVE entries with full raw data (without priorities). """
     res = {}

--- a/main.py
+++ b/main.py
@@ -3,12 +3,14 @@
 import json
 import os
 import subprocess
+import time
+from collections import defaultdict
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
 from typing import Annotated, Any, Literal, Optional
 
 import aiosqlite
-from fastapi import APIRouter, FastAPI, Path
+from fastapi import APIRouter, Depends, FastAPI, Header, HTTPException, Path, Request
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 from starlette.responses import JSONResponse, RedirectResponse
@@ -46,6 +48,10 @@ origins = os.getenv("ALLOW_ORIGINS", "*").split(",")
 cvss_threshold = float(os.getenv("CVSS_THRESHOLD", "6.0"))
 epss_threshold = float(os.getenv("EPSS_THRESHOLD", "0.2"))
 cache_ttl_hours = float(os.getenv("CACHE_TTL_HOURS", "0"))  # 0 = disabled
+api_key_secret = os.getenv("CVE_PAAS_API_KEY")  # None = auth disabled
+rate_limit = int(os.getenv("RATE_LIMIT", "0"))  # requests/minute, 0 = disabled
+
+_rate_counters: dict[str, list[float]] = defaultdict(list)
 
 DB_PATH = "cve_cache.db"
 SCHEMA = "CREATE TABLE IF NOT EXISTS results (cve_id TEXT PRIMARY KEY, data TEXT NOT NULL, cached_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)"
@@ -95,6 +101,11 @@ def _compute_priority(res: dict) -> dict:
     }
 
 
+async def verify_api_key(x_api_key: Annotated[str | None, Header()] = None):
+    if api_key_secret is not None and x_api_key != api_key_secret:
+        raise HTTPException(status_code=401, detail="Invalid or missing X-API-Key")
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     async with aiosqlite.connect(DB_PATH) as db:
@@ -120,7 +131,22 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-v1 = APIRouter(prefix="/v1")
+
+@app.middleware("http")
+async def rate_limit_middleware(request: Request, call_next):
+    if rate_limit <= 0:
+        return await call_next(request)
+    client_ip = request.client.host if request.client else "unknown"
+    now = time.time()
+    window_start = now - 60.0
+    _rate_counters[client_ip] = [t for t in _rate_counters[client_ip] if t > window_start]
+    if len(_rate_counters[client_ip]) >= rate_limit:
+        return JSONResponse({"error": "Rate limit exceeded"}, status_code=429)
+    _rate_counters[client_ip].append(now)
+    return await call_next(request)
+
+
+v1 = APIRouter(prefix="/v1", dependencies=[Depends(verify_api_key)])
 
 
 @app.get("/", tags=["General"], summary="Health check", response_model=StatusResponse)

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -187,6 +187,26 @@ async def test_non_critical_links_is_none(client):
     assert r.json()["Details"]["Links"] is None
 
 
+# --- Response model shape ---
+
+@pytest.mark.asyncio
+async def test_response_shape_get_info(client):
+    with patch("main.subprocess.run", return_value=mock_vulnx(cve_payload())):
+        r = await client.get(f"/v1/get_info/{CVE_ID}")
+    body = r.json()
+    assert "Priority" in body
+    assert "Details" in body
+    details = body["Details"]
+    assert set(details.keys()) == {"CVSS", "EPSS", "is_template", "is_exploited", "is_poc", "Links"}
+
+
+@pytest.mark.asyncio
+async def test_response_shape_homepage(client):
+    r = await client.get("/")
+    body = r.json()
+    assert set(body.keys()) == {"Status", "Endpoint"}
+
+
 # --- Error handling ---
 
 @pytest.mark.asyncio
@@ -195,6 +215,7 @@ async def test_get_info_invalid_json_from_vulnx(client):
     m.stdout = b"not-json"
     with patch("main.subprocess.run", return_value=m):
         r = await client.get(f"/v1/get_info/{CVE_ID}")
+    assert r.status_code == 502
     assert "error" in r.json()
 
 

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -44,27 +44,27 @@ async def test_homepage(client):
 
 @pytest.mark.asyncio
 async def test_get_info_invalid_cve_id(client):
-    r = await client.get("/get_info/INVALID-ID")
+    r = await client.get("/v1/get_info/INVALID-ID")
     assert r.status_code == 422
 
 
 @pytest.mark.asyncio
 async def test_get_info_valid_cve_id_format(client):
     with patch("main.subprocess.run", return_value=mock_vulnx(cve_payload())):
-        r = await client.get(f"/get_info/{CVE_ID}")
+        r = await client.get(f"/v1/get_info/{CVE_ID}")
     assert r.status_code == 200
 
 
 @pytest.mark.asyncio
 async def test_get_info_cve_id_too_short(client):
-    r = await client.get("/get_info/CVE-2024-123")
+    r = await client.get("/v1/get_info/CVE-2024-123")
     assert r.status_code == 422
 
 
 @pytest.mark.asyncio
 async def test_get_info_cve_id_long_format(client):
     with patch("main.subprocess.run", return_value=mock_vulnx(cve_payload(cve_id="CVE-2024-1234567"))):
-        r = await client.get("/get_info/CVE-2024-1234567")
+        r = await client.get("/v1/get_info/CVE-2024-1234567")
     assert r.status_code == 200
 
 
@@ -73,7 +73,7 @@ async def test_get_info_cve_id_long_format(client):
 @pytest.mark.asyncio
 async def test_cache_miss_calls_vulnx(client):
     with patch("main.subprocess.run", return_value=mock_vulnx(cve_payload())) as mock_run:
-        await client.get(f"/get_info/{CVE_ID}")
+        await client.get(f"/v1/get_info/{CVE_ID}")
     mock_run.assert_called_once_with(
         ["vulnx", "id", CVE_ID, "--json"], capture_output=True, check=False
     )
@@ -82,9 +82,9 @@ async def test_cache_miss_calls_vulnx(client):
 @pytest.mark.asyncio
 async def test_cache_hit_skips_vulnx(client):
     with patch("main.subprocess.run", return_value=mock_vulnx(cve_payload())):
-        await client.get(f"/get_info/{CVE_ID}")
+        await client.get(f"/v1/get_info/{CVE_ID}")
     with patch("main.subprocess.run") as mock_run:
-        r = await client.get(f"/get_info/{CVE_ID}")
+        r = await client.get(f"/v1/get_info/{CVE_ID}")
     assert r.status_code == 200
     mock_run.assert_not_called()
 
@@ -94,63 +94,63 @@ async def test_cache_hit_skips_vulnx(client):
 @pytest.mark.asyncio
 async def test_priority_critical_exploited(client):
     with patch("main.subprocess.run", return_value=mock_vulnx(cve_payload(is_exploited=True))):
-        r = await client.get(f"/get_info/{CVE_ID}")
+        r = await client.get(f"/v1/get_info/{CVE_ID}")
     assert r.json()["Priority"] == "Critical"
 
 
 @pytest.mark.asyncio
 async def test_priority_critical_template(client):
     with patch("main.subprocess.run", return_value=mock_vulnx(cve_payload(is_template=True))):
-        r = await client.get(f"/get_info/{CVE_ID}")
+        r = await client.get(f"/v1/get_info/{CVE_ID}")
     assert r.json()["Priority"] == "Critical"
 
 
 @pytest.mark.asyncio
 async def test_priority_critical_poc(client):
     with patch("main.subprocess.run", return_value=mock_vulnx(cve_payload(is_poc=True))):
-        r = await client.get(f"/get_info/{CVE_ID}")
+        r = await client.get(f"/v1/get_info/{CVE_ID}")
     assert r.json()["Priority"] == "Critical"
 
 
 @pytest.mark.asyncio
 async def test_priority_high(client):
     with patch("main.subprocess.run", return_value=mock_vulnx(cve_payload(cvss_score=7.5, epss={"epss_score": 0.5}))):
-        r = await client.get(f"/get_info/{CVE_ID}")
+        r = await client.get(f"/v1/get_info/{CVE_ID}")
     assert r.json()["Priority"] == "High"
 
 
 @pytest.mark.asyncio
 async def test_priority_medium(client):
     with patch("main.subprocess.run", return_value=mock_vulnx(cve_payload(cvss_score=7.5, epss={"epss_score": 0.1}))):
-        r = await client.get(f"/get_info/{CVE_ID}")
+        r = await client.get(f"/v1/get_info/{CVE_ID}")
     assert r.json()["Priority"] == "Medium"
 
 
 @pytest.mark.asyncio
 async def test_priority_low(client):
     with patch("main.subprocess.run", return_value=mock_vulnx(cve_payload(cvss_score=5.0, epss={"epss_score": 0.5}))):
-        r = await client.get(f"/get_info/{CVE_ID}")
+        r = await client.get(f"/v1/get_info/{CVE_ID}")
     assert r.json()["Priority"] == "Low"
 
 
 @pytest.mark.asyncio
 async def test_priority_info(client):
     with patch("main.subprocess.run", return_value=mock_vulnx(cve_payload(cvss_score=5.0, epss={"epss_score": 0.1}))):
-        r = await client.get(f"/get_info/{CVE_ID}")
+        r = await client.get(f"/v1/get_info/{CVE_ID}")
     assert r.json()["Priority"] == "Info"
 
 
 @pytest.mark.asyncio
 async def test_priority_undefined_missing_cvss(client):
     with patch("main.subprocess.run", return_value=mock_vulnx(cve_payload(cvss_score=None))):
-        r = await client.get(f"/get_info/{CVE_ID}")
+        r = await client.get(f"/v1/get_info/{CVE_ID}")
     assert r.json()["Priority"] == "Undefined"
 
 
 @pytest.mark.asyncio
 async def test_priority_undefined_missing_epss(client):
     with patch("main.subprocess.run", return_value=mock_vulnx(cve_payload(epss=None))):
-        r = await client.get(f"/get_info/{CVE_ID}")
+        r = await client.get(f"/v1/get_info/{CVE_ID}")
     assert r.json()["Priority"] == "Undefined"
 
 
@@ -158,7 +158,7 @@ async def test_priority_undefined_missing_epss(client):
 async def test_priority_cvss_integer_not_undefined(client):
     # Bug: isinstance(7, float) is False — cvss_score as int must still work
     with patch("main.subprocess.run", return_value=mock_vulnx(cve_payload(cvss_score=7, epss={"epss_score": 0.5}))):
-        r = await client.get(f"/get_info/{CVE_ID}")
+        r = await client.get(f"/v1/get_info/{CVE_ID}")
     assert r.json()["Priority"] == "High"
 
 
@@ -166,14 +166,14 @@ async def test_priority_cvss_integer_not_undefined(client):
 async def test_priority_threshold_boundary_exact(client):
     # Exactly at threshold: 6.0 > 6.0 is False → not High/Medium
     with patch("main.subprocess.run", return_value=mock_vulnx(cve_payload(cvss_score=6.0, epss={"epss_score": 0.2}))):
-        r = await client.get(f"/get_info/{CVE_ID}")
+        r = await client.get(f"/v1/get_info/{CVE_ID}")
     assert r.json()["Priority"] == "Info"
 
 
 @pytest.mark.asyncio
 async def test_critical_links_populated(client):
     with patch("main.subprocess.run", return_value=mock_vulnx(cve_payload(is_poc=True, poc="https://poc.example"))):
-        r = await client.get(f"/get_info/{CVE_ID}")
+        r = await client.get(f"/v1/get_info/{CVE_ID}")
     body = r.json()
     assert body["Priority"] == "Critical"
     assert body["Details"]["Links"]["POC"] == "https://poc.example"
@@ -183,7 +183,7 @@ async def test_critical_links_populated(client):
 async def test_non_critical_links_is_none(client):
     # Bug: links initialised as "" — should be None for non-Critical
     with patch("main.subprocess.run", return_value=mock_vulnx(cve_payload(cvss_score=7.5, epss={"epss_score": 0.5}))):
-        r = await client.get(f"/get_info/{CVE_ID}")
+        r = await client.get(f"/v1/get_info/{CVE_ID}")
     assert r.json()["Details"]["Links"] is None
 
 
@@ -194,7 +194,7 @@ async def test_get_info_invalid_json_from_vulnx(client):
     m = MagicMock()
     m.stdout = b"not-json"
     with patch("main.subprocess.run", return_value=m):
-        r = await client.get(f"/get_info/{CVE_ID}")
+        r = await client.get(f"/v1/get_info/{CVE_ID}")
     assert "error" in r.json()
 
 
@@ -202,7 +202,7 @@ async def test_get_info_invalid_json_from_vulnx(client):
 
 @pytest.mark.asyncio
 async def test_delete_results_empty_db(client):
-    r = await client.delete("/results")
+    r = await client.delete("/v1/results")
     assert r.status_code == 200
     assert r.json()["Status"] == "OK"
 
@@ -210,11 +210,11 @@ async def test_delete_results_empty_db(client):
 @pytest.mark.asyncio
 async def test_delete_results_clears_cache(client):
     with patch("main.subprocess.run", return_value=mock_vulnx(cve_payload())):
-        await client.get(f"/get_info/{CVE_ID}")
-    await client.delete("/results")
+        await client.get(f"/v1/get_info/{CVE_ID}")
+    await client.delete("/v1/results")
     with patch("main.subprocess.run") as mock_run:
         mock_run.return_value = mock_vulnx(cve_payload())
-        await client.get(f"/get_info/{CVE_ID}")
+        await client.get(f"/v1/get_info/{CVE_ID}")
     mock_run.assert_called_once()
 
 
@@ -222,7 +222,7 @@ async def test_delete_results_clears_cache(client):
 
 @pytest.mark.asyncio
 async def test_all_results_empty(client):
-    r = await client.get("/all_results")
+    r = await client.get("/v1/all_results")
     assert r.status_code == 200
     assert r.json() == {}
 
@@ -230,8 +230,8 @@ async def test_all_results_empty(client):
 @pytest.mark.asyncio
 async def test_all_results_populated(client):
     with patch("main.subprocess.run", return_value=mock_vulnx(cve_payload())):
-        await client.get(f"/get_info/{CVE_ID}")
-    r = await client.get("/all_results")
+        await client.get(f"/v1/get_info/{CVE_ID}")
+    r = await client.get("/v1/all_results")
     assert CVE_ID in r.json()
 
 
@@ -239,10 +239,10 @@ async def test_all_results_populated(client):
 async def test_all_results_multiple(client):
     cve2 = "CVE-2024-9999"
     with patch("main.subprocess.run", return_value=mock_vulnx(cve_payload())):
-        await client.get(f"/get_info/{CVE_ID}")
+        await client.get(f"/v1/get_info/{CVE_ID}")
     with patch("main.subprocess.run", return_value=mock_vulnx(cve_payload(cve_id=cve2))):
-        await client.get(f"/get_info/{cve2}")
-    r = await client.get("/all_results")
+        await client.get(f"/v1/get_info/{cve2}")
+    r = await client.get("/v1/all_results")
     body = r.json()
     assert CVE_ID in body
     assert cve2 in body
@@ -253,10 +253,10 @@ async def test_all_results_multiple(client):
 @pytest.mark.asyncio
 async def test_reget_info_invalidates_cache(client):
     with patch("main.subprocess.run", return_value=mock_vulnx(cve_payload(cvss_score=5.0))):
-        await client.get(f"/get_info/{CVE_ID}")
+        await client.get(f"/v1/get_info/{CVE_ID}")
     with patch("main.subprocess.run") as mock_run:
         mock_run.return_value = mock_vulnx(cve_payload(cvss_score=9.0))
-        r = await client.get(f"/reget_info/{CVE_ID}", follow_redirects=True)
+        r = await client.get(f"/v1/reget_info/{CVE_ID}", follow_redirects=True)
     assert r.status_code == 200
     mock_run.assert_called_once()
     assert r.json()["Details"]["CVSS"] == 9.0
@@ -264,7 +264,7 @@ async def test_reget_info_invalidates_cache(client):
 
 @pytest.mark.asyncio
 async def test_reget_info_invalid_cve_id(client):
-    r = await client.get("/reget_info/NOT-A-CVE")
+    r = await client.get("/v1/reget_info/NOT-A-CVE")
     assert r.status_code == 422
 
 
@@ -283,5 +283,5 @@ async def test_custom_thresholds(tmp_path, monkeypatch):
     async with AsyncClient(transport=ASGITransport(app=main.app), base_url="http://test") as ac:
         # cvss=7.5, epss=0.5 → with defaults: High; with new thresholds: Low (cvss not > 8.0)
         with patch("main.subprocess.run", return_value=mock_vulnx(cve_payload(cvss_score=7.5, epss={"epss_score": 0.5}))):
-            r = await ac.get(f"/get_info/{CVE_ID}")
+            r = await ac.get(f"/v1/get_info/{CVE_ID}")
     assert r.json()["Priority"] == "Low"

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -455,3 +455,90 @@ async def test_bulk_preserves_order(client):
     with patch("main.subprocess.run", return_value=mock_vulnx(payload)):
         r = await client.post("/v1/cve", json={"cve_ids": [CVE_ID, cve2]})
     assert list(r.json().keys()) == [CVE_ID, cve2]
+
+
+# --- API auth ---
+
+@pytest.mark.asyncio
+async def test_auth_disabled_no_key_required(client, monkeypatch):
+    monkeypatch.setattr(main, "api_key_secret", None)
+    r = await client.get("/")
+    assert r.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_auth_enabled_missing_key_returns_401(client, monkeypatch):
+    monkeypatch.setattr(main, "api_key_secret", "secret123")
+    r = await client.get(f"/v1/get_info/{CVE_ID}")
+    assert r.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_auth_enabled_wrong_key_returns_401(client, monkeypatch):
+    monkeypatch.setattr(main, "api_key_secret", "secret123")
+    r = await client.get(f"/v1/get_info/{CVE_ID}", headers={"X-API-Key": "wrong"})
+    assert r.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_auth_enabled_correct_key_passes(client, monkeypatch):
+    monkeypatch.setattr(main, "api_key_secret", "secret123")
+    with patch("main.subprocess.run", return_value=mock_vulnx(cve_payload())):
+        r = await client.get(f"/v1/get_info/{CVE_ID}", headers={"X-API-Key": "secret123"})
+    assert r.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_auth_does_not_protect_homepage(client, monkeypatch):
+    monkeypatch.setattr(main, "api_key_secret", "secret123")
+    r = await client.get("/")
+    assert r.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_auth_bulk_endpoint_requires_key(client, monkeypatch):
+    monkeypatch.setattr(main, "api_key_secret", "secret123")
+    r = await client.post("/v1/cve", json={"cve_ids": [CVE_ID]})
+    assert r.status_code == 401
+
+
+# --- Rate limiting ---
+
+@pytest.mark.asyncio
+async def test_rate_limit_disabled(client, monkeypatch):
+    monkeypatch.setattr(main, "rate_limit", 0)
+    main._rate_counters.clear()
+    for _ in range(5):
+        r = await client.get("/")
+    assert r.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_allows_up_to_limit(client, monkeypatch):
+    monkeypatch.setattr(main, "rate_limit", 3)
+    main._rate_counters.clear()
+    for _ in range(3):
+        r = await client.get("/")
+    assert r.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_blocks_over_limit(client, monkeypatch):
+    monkeypatch.setattr(main, "rate_limit", 3)
+    main._rate_counters.clear()
+    for _ in range(3):
+        await client.get("/")
+    r = await client.get("/")
+    assert r.status_code == 429
+    assert "error" in r.json()
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_applies_to_v1(client, monkeypatch):
+    monkeypatch.setattr(main, "rate_limit", 2)
+    main._rate_counters.clear()
+    with patch("main.subprocess.run", return_value=mock_vulnx(cve_payload())):
+        await client.get(f"/v1/get_info/{CVE_ID}")
+        await client.get(f"/v1/get_info/{CVE_ID}")
+    r = await client.get(f"/v1/get_info/{CVE_ID}")
+    assert r.status_code == 429

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -246,7 +246,9 @@ async def test_delete_results_clears_cache(client):
 async def test_all_results_empty(client):
     r = await client.get("/v1/all_results")
     assert r.status_code == 200
-    assert r.json() == {}
+    body = r.json()
+    assert body["total"] == 0
+    assert body["results"] == {}
 
 
 @pytest.mark.asyncio
@@ -254,7 +256,9 @@ async def test_all_results_populated(client):
     with patch("main.subprocess.run", return_value=mock_vulnx(cve_payload())):
         await client.get(f"/v1/get_info/{CVE_ID}")
     r = await client.get("/v1/all_results")
-    assert CVE_ID in r.json()
+    body = r.json()
+    assert body["total"] == 1
+    assert CVE_ID in body["results"]
 
 
 @pytest.mark.asyncio
@@ -266,8 +270,64 @@ async def test_all_results_multiple(client):
         await client.get(f"/v1/get_info/{cve2}")
     r = await client.get("/v1/all_results")
     body = r.json()
-    assert CVE_ID in body
-    assert cve2 in body
+    assert body["total"] == 2
+    assert CVE_ID in body["results"]
+    assert cve2 in body["results"]
+
+
+@pytest.mark.asyncio
+async def test_all_results_pagination_limit(client):
+    cve2 = "CVE-2024-9999"
+    with patch("main.subprocess.run", return_value=mock_vulnx(cve_payload())):
+        await client.get(f"/v1/get_info/{CVE_ID}")
+    with patch("main.subprocess.run", return_value=mock_vulnx(cve_payload(cve_id=cve2))):
+        await client.get(f"/v1/get_info/{cve2}")
+    r = await client.get("/v1/all_results?limit=1")
+    body = r.json()
+    assert body["total"] == 2
+    assert body["limit"] == 1
+    assert len(body["results"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_all_results_pagination_offset(client):
+    cve2 = "CVE-2024-9999"
+    with patch("main.subprocess.run", return_value=mock_vulnx(cve_payload())):
+        await client.get(f"/v1/get_info/{CVE_ID}")
+    with patch("main.subprocess.run", return_value=mock_vulnx(cve_payload(cve_id=cve2))):
+        await client.get(f"/v1/get_info/{cve2}")
+    r = await client.get("/v1/all_results?offset=1&limit=10")
+    body = r.json()
+    assert body["total"] == 2
+    assert body["offset"] == 1
+    assert len(body["results"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_all_results_pagination_beyond_end(client):
+    with patch("main.subprocess.run", return_value=mock_vulnx(cve_payload())):
+        await client.get(f"/v1/get_info/{CVE_ID}")
+    r = await client.get("/v1/all_results?offset=100")
+    body = r.json()
+    assert body["total"] == 1
+    assert body["results"] == {}
+
+
+@pytest.mark.asyncio
+async def test_all_results_response_shape(client):
+    r = await client.get("/v1/all_results")
+    body = r.json()
+    assert set(body.keys()) == {"total", "offset", "limit", "results"}
+
+
+@pytest.mark.asyncio
+async def test_all_results_invalid_params(client):
+    r = await client.get("/v1/all_results?limit=0")
+    assert r.status_code == 422
+    r = await client.get("/v1/all_results?offset=-1")
+    assert r.status_code == 422
+    r = await client.get("/v1/all_results?limit=1001")
+    assert r.status_code == 422
 
 
 # --- GET /reget_info ---

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -343,3 +343,115 @@ async def test_custom_thresholds(tmp_path, monkeypatch):
         with patch("main.subprocess.run", return_value=mock_vulnx(cve_payload(cvss_score=7.5, epss={"epss_score": 0.5}))):
             r = await ac.get(f"/v1/get_info/{CVE_ID}")
     assert r.json()["Priority"] == "Low"
+
+
+# --- POST /v1/cve (bulk) ---
+
+@pytest.mark.asyncio
+async def test_bulk_single_cve(client):
+    with patch("main.subprocess.run", return_value=mock_vulnx([cve_payload()])):
+        r = await client.post("/v1/cve", json={"cve_ids": [CVE_ID]})
+    assert r.status_code == 200
+    body = r.json()
+    assert CVE_ID in body
+    assert body[CVE_ID]["Priority"] == "High"
+
+
+@pytest.mark.asyncio
+async def test_bulk_multiple_cves(client):
+    cve2 = "CVE-2024-9999"
+    payload = [cve_payload(), cve_payload(cve_id=cve2, cvss_score=5.0, epss={"epss_score": 0.1})]
+    with patch("main.subprocess.run", return_value=mock_vulnx(payload)):
+        r = await client.post("/v1/cve", json={"cve_ids": [CVE_ID, cve2]})
+    assert r.status_code == 200
+    body = r.json()
+    assert body[CVE_ID]["Priority"] == "High"
+    assert body[cve2]["Priority"] == "Info"
+
+
+@pytest.mark.asyncio
+async def test_bulk_deduplication(client):
+    with patch("main.subprocess.run", return_value=mock_vulnx([cve_payload()])) as mock_run:
+        r = await client.post("/v1/cve", json={"cve_ids": [CVE_ID, CVE_ID, CVE_ID]})
+    assert r.status_code == 200
+    body = r.json()
+    assert list(body.keys()) == [CVE_ID]
+    mock_run.assert_called_once_with(
+        ["vulnx", "id", CVE_ID, "--json"], capture_output=True, check=False
+    )
+
+
+@pytest.mark.asyncio
+async def test_bulk_cache_hit_skips_vulnx(client):
+    with patch("main.subprocess.run", return_value=mock_vulnx([cve_payload()])):
+        await client.post("/v1/cve", json={"cve_ids": [CVE_ID]})
+    with patch("main.subprocess.run") as mock_run:
+        r = await client.post("/v1/cve", json={"cve_ids": [CVE_ID]})
+    assert r.status_code == 200
+    mock_run.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_bulk_partial_cache(client):
+    cve2 = "CVE-2024-8888"
+    with patch("main.subprocess.run", return_value=mock_vulnx([cve_payload()])):
+        await client.post("/v1/cve", json={"cve_ids": [CVE_ID]})
+    with patch("main.subprocess.run", return_value=mock_vulnx([cve_payload(cve_id=cve2)])) as mock_run:
+        r = await client.post("/v1/cve", json={"cve_ids": [CVE_ID, cve2]})
+    assert r.status_code == 200
+    mock_run.assert_called_once_with(
+        ["vulnx", "id", cve2, "--json"], capture_output=True, check=False
+    )
+    body = r.json()
+    assert CVE_ID in body
+    assert cve2 in body
+
+
+@pytest.mark.asyncio
+async def test_bulk_invalid_cve_id(client):
+    r = await client.post("/v1/cve", json={"cve_ids": ["NOT-A-CVE"]})
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_bulk_empty_list(client):
+    r = await client.post("/v1/cve", json={"cve_ids": []})
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_bulk_too_many_cves(client):
+    cve_ids = [f"CVE-2024-{1000 + i}" for i in range(51)]
+    r = await client.post("/v1/cve", json={"cve_ids": cve_ids})
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_bulk_invalid_json_from_vulnx(client):
+    m = MagicMock()
+    m.stdout = b"not-json"
+    with patch("main.subprocess.run", return_value=m):
+        r = await client.post("/v1/cve", json={"cve_ids": [CVE_ID]})
+    assert r.status_code == 502
+    assert "error" in r.json()
+
+
+@pytest.mark.asyncio
+async def test_bulk_response_shape(client):
+    with patch("main.subprocess.run", return_value=mock_vulnx([cve_payload()])):
+        r = await client.post("/v1/cve", json={"cve_ids": [CVE_ID]})
+    body = r.json()
+    assert CVE_ID in body
+    entry = body[CVE_ID]
+    assert "Priority" in entry
+    assert "Details" in entry
+    assert set(entry["Details"].keys()) == {"CVSS", "EPSS", "is_template", "is_exploited", "is_poc", "Links"}
+
+
+@pytest.mark.asyncio
+async def test_bulk_preserves_order(client):
+    cve2 = "CVE-2024-7777"
+    payload = [cve_payload(), cve_payload(cve_id=cve2)]
+    with patch("main.subprocess.run", return_value=mock_vulnx(payload)):
+        r = await client.post("/v1/cve", json={"cve_ids": [CVE_ID, cve2]})
+    assert list(r.json().keys()) == [CVE_ID, cve2]

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,6 +1,7 @@
 import json
 from unittest.mock import MagicMock, patch
 
+import aiosqlite
 import pytest
 import pytest_asyncio
 from httpx import AsyncClient, ASGITransport
@@ -287,6 +288,42 @@ async def test_reget_info_invalidates_cache(client):
 async def test_reget_info_invalid_cve_id(client):
     r = await client.get("/v1/reget_info/NOT-A-CVE")
     assert r.status_code == 422
+
+
+# --- Cache TTL ---
+
+@pytest.mark.asyncio
+async def test_ttl_disabled_serves_cached(client, monkeypatch):
+    monkeypatch.setattr(main, "cache_ttl_hours", 0.0)
+    with patch("main.subprocess.run", return_value=mock_vulnx(cve_payload())) as mock_run:
+        await client.get(f"/v1/get_info/{CVE_ID}")
+        await client.get(f"/v1/get_info/{CVE_ID}")
+    mock_run.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_ttl_fresh_entry_serves_cache(client, monkeypatch):
+    monkeypatch.setattr(main, "cache_ttl_hours", 24.0)
+    with patch("main.subprocess.run", return_value=mock_vulnx(cve_payload())) as mock_run:
+        await client.get(f"/v1/get_info/{CVE_ID}")
+        await client.get(f"/v1/get_info/{CVE_ID}")
+    mock_run.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_ttl_expired_entry_refetches(client, monkeypatch):
+    monkeypatch.setattr(main, "cache_ttl_hours", 24.0)
+    with patch("main.subprocess.run", return_value=mock_vulnx(cve_payload())):
+        await client.get(f"/v1/get_info/{CVE_ID}")
+    # Backdate cached_at to simulate expiry
+    async with aiosqlite.connect(main.DB_PATH) as db:
+        await db.execute("UPDATE results SET cached_at = '2000-01-01 00:00:00' WHERE cve_id = ?", (CVE_ID,))
+        await db.commit()
+    with patch("main.subprocess.run") as mock_run:
+        mock_run.return_value = mock_vulnx(cve_payload(cvss_score=9.9))
+        r = await client.get(f"/v1/get_info/{CVE_ID}")
+    mock_run.assert_called_once()
+    assert r.json()["Details"]["CVSS"] == 9.9
 
 
 # --- Threshold override ---


### PR DESCRIPTION
## Summary

- **Bulk endpoint** `POST /v1/cve` — batch lookup up to 50 CVEs, cache-aware (vulnx вызывается только для отсутствующих/устаревших)
- **API auth** — опциональный `X-API-Key` заголовок на всех `/v1/` роутах (`CVE_PAAS_API_KEY` env, 401 при неверном ключе)
- **Rate limiting** — sliding window по IP, `RATE_LIMIT` запросов/минуту (`RATE_LIMIT` env, 0 = отключено, 429 при превышении)
- **Пагинация** `GET /v1/all_results` — параметры `offset`/`limit` (default 0/100, max limit 1000), response включает `total`
- **Логирование** — stdlib logging: cache hit/miss/stale, vulnx вызовы, bulk stats, auth rejection, rate limit 429, DB ошибки
- **Баг-фикс** — утечка памяти в `_rate_counters`: фоновая задача в lifespan чистит stale IP каждые 5 мин
- **Рефакторинг** — `_compute_priority()` и `_is_stale()` вынесены в helpers, убрано дублирование
- **README** — добавлена таблица Required/Optional env vars, bulk endpoint в Usage, roadmap обновлён
- **Тесты** — 60 тестов (было 34), покрыты все новые фичи

## New env vars

| Variable | Default | Description |
|---|---|---|
| `CVE_PAAS_API_KEY` | not set | Enables API key auth on /v1/ routes |
| `RATE_LIMIT` | `0` | Max requests/minute per IP (0 = disabled) |

## Test plan

- [x] `pytest tests/ -q` — 60/60 passed
- [ ] Merge to `develop`, проверить docker build