### PR TITLE
feat: retry mechanism, error records, and retry_errors endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Environment variables (pass via `docker run --env`):
 | `DB_PATH` | `cve_cache.db` | Path to the SQLite cache file inside the container |
 | `VULNX_BATCH_SIZE` | `5` | CVEs per single vulnx API call — reduce if hitting PDCP rate limits |
 | `VULNX_BATCH_DELAY` | `2.0` | Seconds to wait between batch calls to avoid PDCP rate limits (0 = no delay) |
+| `VULNX_RETRY_COUNT` | `3` | Total fetch attempts per batch (1 = no retry) — retries on timeout or rate-limit errors |
+| `VULNX_RETRY_DELAY` | `5.0` | Seconds to wait between retry attempts |
 
 ### Data persistence
 The SQLite cache is stored at the path defined by `DB_PATH` (default `/app/cve_cache.db`). Without a volume mount the cache is lost on container restart. To persist it:
@@ -61,6 +63,7 @@ All API Endpoints described on [localhost:8000/docs](localhost:8000/docs):
 - *POST /v1/cve* - Bulk lookup: accepts `{"cve_ids": ["CVE-YYYY-NNNNN", ...]}` (1–50 IDs), returns map of CVE ID → priority result
 - *GET /v1/reget_info/{cve_id}* - Force refresh: invalidate cache and re-fetch from vulnx
 - *GET /v1/all_results* - Return cached results with full raw info (without priorities); supports `?offset=0&limit=100` (max 1000)
+- *POST /v1/retry_errors* - Re-fetch all CVEs that previously failed to load (stored as error records)
 - *DELETE /v1/results* - Remove all cached results (use when results outdated)
 ## Use Cases
 
@@ -118,6 +121,8 @@ curl -X POST http://localhost:8000/v1/cve \
 ```
 
 Only CVEs not already cached will trigger a vulnx call — the rest are served instantly from SQLite.
+
+> **Note on transient fetch failures:** When the PDCP upstream is temporarily unavailable or rate-limits your key, individual CVEs in a batch may fail even after retries. Those CVEs are stored in the cache as **error records** and returned with an `"error"` key instead of `"Priority"`. They are automatically excluded from `/v1/all_results` and will be re-fetched on the next request that includes them. You can also recover them all at once with `POST /v1/retry_errors` (see [use case 7](#7-recover-after-upstream-failure)).
 
 ---
 
@@ -187,6 +192,29 @@ curl -X DELETE http://localhost:8000/v1/results
 ```json
 { "Status": "OK", "Endpoint": "remove_results" }
 ```
+
+---
+
+### 7. Recover after upstream failure
+
+After a PDCP outage or rate-limit window, some CVEs in a bulk request may be stored as **error records**. Recover them all in one call:
+
+```bash
+curl -X POST http://localhost:8000/v1/retry_errors
+```
+
+```json
+{
+  "retried": 3,
+  "results": {
+    "CVE-2024-1111": { "Priority": "High", "Details": { ... } },
+    "CVE-2024-2222": { "Priority": "Medium", "Details": { ... } },
+    "CVE-2024-3333": { "error": "vulnx error: Rate limit exceeded" }
+  }
+}
+```
+
+`retried` is the number of error records found. CVEs that still fail are stored as error records again and can be retried later. You can tune retry behaviour with `VULNX_RETRY_COUNT` (default 3 total attempts) and `VULNX_RETRY_DELAY` (default 5 s between attempts).
 
 ## Roadmap
 ### Done

--- a/main.py
+++ b/main.py
@@ -61,6 +61,11 @@ class AllResultsResponse(BaseModel):
     results: dict[str, Any]
 
 
+class RetryErrorsResponse(BaseModel):
+    retried: int
+    results: dict[str, Any]
+
+
 origins = os.getenv("ALLOW_ORIGINS", "*").split(",")
 cvss_threshold = float(os.getenv("CVSS_THRESHOLD", "6.0"))
 epss_threshold = float(os.getenv("EPSS_THRESHOLD", "0.2"))
@@ -69,6 +74,8 @@ api_key_secret = os.getenv("CVE_PAAS_API_KEY")  # None = auth disabled
 rate_limit = int(os.getenv("RATE_LIMIT", "0"))  # requests/minute, 0 = disabled
 vulnx_batch_size = int(os.getenv("VULNX_BATCH_SIZE", "5"))  # CVEs per vulnx call
 vulnx_batch_delay = float(os.getenv("VULNX_BATCH_DELAY", "2.0"))  # seconds between batches
+vulnx_retry_count = int(os.getenv("VULNX_RETRY_COUNT", "3"))  # total attempts per batch (1 = no retry)
+vulnx_retry_delay = float(os.getenv("VULNX_RETRY_DELAY", "5.0"))  # seconds between retry attempts
 
 _rate_counters: dict[str, list[float]] = defaultdict(list)
 
@@ -93,6 +100,14 @@ def _is_stale(cached_at_str: str) -> bool:
         return False
     cached_at = datetime.strptime(cached_at_str, "%Y-%m-%d %H:%M:%S").replace(tzinfo=timezone.utc)
     return datetime.now(timezone.utc) - cached_at > timedelta(hours=cache_ttl_hours)
+
+
+def _is_error_record(data_str: str) -> bool:
+    """ Return True if data_str is a stored fetch-error marker. """
+    try:
+        return bool(json.loads(data_str).get("__error__"))
+    except (json.JSONDecodeError, AttributeError):
+        return False
 
 
 def _compute_priority(res: dict) -> dict:
@@ -134,6 +149,42 @@ def _compute_priority(res: dict) -> dict:
             "Links": links,
         },
     }
+
+
+async def _fetch_batch_with_retry(chunk: list[str]) -> tuple[list[dict], str | None]:
+    """
+    Fetch a batch of CVE IDs from vulnx with automatic retry on failure.
+    Returns (items, None) on success or ([], error_msg) after all attempts exhausted.
+    """
+    attempts = max(1, vulnx_retry_count)
+    last_error: str | None = None
+    for attempt in range(attempts):
+        if attempt > 0:
+            logger.info("Batch retry %d/%d for: %s", attempt, attempts - 1, ", ".join(chunk))
+            await asyncio.sleep(vulnx_retry_delay)
+        try:
+            output = await asyncio.to_thread(
+                subprocess.run,
+                ["vulnx", "id", ",".join(chunk), "--json"],
+                capture_output=True, check=False, timeout=30,
+            )
+        except subprocess.TimeoutExpired:
+            last_error = "vulnx request timed out"
+            logger.warning("vulnx timed out for batch (attempt %d/%d): %s", attempt + 1, attempts, ", ".join(chunk))
+            continue
+        if output.returncode != 0 or not output.stdout.strip():
+            last_error = f"vulnx error: {_extract_vulnx_error(output.stderr.decode())}"
+            logger.warning("vulnx error for batch (attempt %d/%d, exit %d): %s", attempt + 1, attempts, output.returncode, last_error)
+            continue
+        try:
+            raw = json.loads(output.stdout.decode())
+        except json.JSONDecodeError as e:
+            last_error = str(e)
+            logger.warning("vulnx invalid JSON for batch (attempt %d/%d): %s", attempt + 1, attempts, e)
+            continue
+        return raw if isinstance(raw, list) else [raw], None
+    logger.error("All %d attempt(s) failed for batch: %s — last error: %s", attempts, ", ".join(chunk), last_error)
+    return [], last_error
 
 
 async def verify_api_key(x_api_key: Annotated[str | None, Header()] = None):
@@ -269,8 +320,8 @@ async def get_info(cve_id: Annotated[str, Path(
         async with aiosqlite.connect(DB_PATH) as db:
             async with db.execute("SELECT data, cached_at FROM results WHERE cve_id = ?", (cve_id,)) as cursor:
                 row = await cursor.fetchone()
-            if row is not None and _is_stale(row[1]):
-                logger.info("Cache stale for %s, re-fetching", cve_id)
+            if row is not None and (_is_stale(row[1]) or _is_error_record(row[0])):
+                logger.info("Cache stale or error record for %s, re-fetching", cve_id)
                 row = None
             if row is None:
                 logger.info("Cache miss for %s, calling vulnx", cve_id)
@@ -307,7 +358,11 @@ async def get_info(cve_id: Annotated[str, Path(
 
 @v1.post("/cve", tags=["CVE"], summary="Get priority for multiple CVEs (bulk)", response_model=None)
 async def bulk_get_info(body: BulkRequest):
-    """ Fetch CVE data for up to 50 CVEs. Cache-aware: calls vulnx only for missing or stale entries. """
+    """
+    Fetch CVE data for up to 50 CVEs. Cache-aware: calls vulnx only for missing or stale entries.
+    Failed CVEs (after retries) are stored as error records in cache and returned with an \"error\" key.
+    Use POST /v1/retry_errors to re-fetch them when the upstream service recovers.
+    """
     unique_ids = list(dict.fromkeys(body.cve_ids))  # deduplicate, preserve order
     results: dict[str, Any] = {}
 
@@ -322,45 +377,40 @@ async def bulk_get_info(body: BulkRequest):
 
             missing = [
                 cve_id for cve_id in unique_ids
-                if cve_id not in cached or _is_stale(cached[cve_id][1])
+                if cve_id not in cached
+                or _is_stale(cached[cve_id][1])
+                or _is_error_record(cached[cve_id][0])
             ]
             logger.info("Bulk lookup: %d total, %d cached, %d missing", len(unique_ids), len(unique_ids) - len(missing), len(missing))
 
             if missing:
                 chunks = [missing[i:i + vulnx_batch_size] for i in range(0, len(missing), vulnx_batch_size)]
-                logger.info("Calling vulnx for %d CVEs in %d batch(es)", len(missing), len(chunks))
+                logger.info("Calling vulnx for %d CVEs in %d batch(es) (up to %d attempt(s) each)", len(missing), len(chunks), vulnx_retry_count)
                 for i, chunk in enumerate(chunks):
                     if i > 0 and vulnx_batch_delay > 0:
                         await asyncio.sleep(vulnx_batch_delay)
-                    logger.info("Fetching batch: %s", ", ".join(chunk))
-                    try:
-                        output = await asyncio.to_thread(
-                            subprocess.run,
-                            ["vulnx", "id", ",".join(chunk), "--json"],
-                            capture_output=True, check=False, timeout=30,
-                        )
-                    except subprocess.TimeoutExpired:
-                        logger.error("vulnx timed out for batch: %s", ", ".join(chunk))
-                        return JSONResponse({"error": "vulnx request timed out"}, status_code=504)
-                    if output.returncode != 0 or not output.stdout.strip():
-                        stderr = _extract_vulnx_error(output.stderr.decode())
-                        logger.error("vulnx error for batch (exit %d): %s", output.returncode, stderr)
-                        return JSONResponse({"error": f"vulnx error: {stderr}"}, status_code=502)
-                    try:
-                        raw = json.loads(output.stdout.decode())
-                    except json.JSONDecodeError as e:
-                        logger.error("vulnx returned invalid JSON for batch: %s", e)
-                        return JSONResponse({"error": str(e)}, status_code=502)
-
-                    items = raw if isinstance(raw, list) else [raw]
-                    for item in items:
-                        item_id = item.get("cve_id")
-                        if item_id:
+                    logger.info("Fetching batch %d/%d: %s", i + 1, len(chunks), ", ".join(chunk))
+                    items, error = await _fetch_batch_with_retry(chunk)
+                    if error:
+                        # Store error markers so the caller knows which CVEs failed,
+                        # and so /all_results can exclude them until retried.
+                        for cve_id in chunk:
+                            err_data = json.dumps({"__error__": True, "message": error})
                             await db.execute(
                                 "INSERT OR REPLACE INTO results (cve_id, data, cached_at) VALUES (?, ?, CURRENT_TIMESTAMP)",
-                                (item_id, json.dumps(item)),
+                                (cve_id, err_data),
                             )
-                            cached[item_id] = (json.dumps(item), None)
+                            cached[cve_id] = (err_data, None)
+                        logger.warning("Batch %d/%d failed, stored error records for: %s", i + 1, len(chunks), ", ".join(chunk))
+                    else:
+                        for item in items:
+                            item_id = item.get("cve_id")
+                            if item_id:
+                                await db.execute(
+                                    "INSERT OR REPLACE INTO results (cve_id, data, cached_at) VALUES (?, ?, CURRENT_TIMESTAMP)",
+                                    (item_id, json.dumps(item)),
+                                )
+                                cached[item_id] = (json.dumps(item), None)
                 await db.commit()
 
     except aiosqlite.Error as e:
@@ -370,12 +420,58 @@ async def bulk_get_info(body: BulkRequest):
         if cve_id not in cached:
             results[cve_id] = {"error": "not found in vulnx response"}
             continue
+        data_str = cached[cve_id][0]
+        if _is_error_record(data_str):
+            try:
+                msg = json.loads(data_str).get("message", "fetch failed")
+            except (json.JSONDecodeError, AttributeError):
+                msg = "fetch failed"
+            results[cve_id] = {"error": msg}
+            continue
         try:
-            results[cve_id] = _compute_priority(json.loads(cached[cve_id][0]))
-        except (json.JSONDecodeError, Exception) as e:
+            results[cve_id] = _compute_priority(json.loads(data_str))
+        except Exception as e:
             results[cve_id] = {"error": str(e)}
 
     return results
+
+
+@v1.post("/retry_errors", tags=["Results"], summary="Retry all failed CVE fetches", response_model=RetryErrorsResponse)
+async def retry_errors():
+    """
+    Find all CVEs stored as fetch-error records, delete them, and re-fetch from vulnx.
+    Returns the count of retried CVEs and their new priority results (or new error entries if still failing).
+    Useful after a PDCP outage or rate-limit window to recover partial bulk results.
+    """
+    try:
+        async with aiosqlite.connect(DB_PATH) as db:
+            async with db.execute(
+                "SELECT cve_id FROM results WHERE json_extract(data, '$.__error__') = 1"
+            ) as cursor:
+                error_ids = [row[0] for row in await cursor.fetchall()]
+            if error_ids:
+                placeholders = ",".join("?" * len(error_ids))
+                await db.execute(f"DELETE FROM results WHERE cve_id IN ({placeholders})", error_ids)
+                await db.commit()
+    except aiosqlite.Error as e:
+        logger.error("DB error in retry_errors: %s", e)
+        return JSONResponse({"error": str(e)}, status_code=500)
+
+    if not error_ids:
+        logger.info("retry_errors: no error records found")
+        return {"retried": 0, "results": {}}
+
+    logger.info("retry_errors: retrying %d CVE(s)", len(error_ids))
+    all_results: dict[str, Any] = {}
+    # Re-fetch in chunks of 50 (BulkRequest limit) to reuse all caching and retry logic
+    for i in range(0, len(error_ids), 50):
+        chunk = error_ids[i:i + 50]
+        chunk_result = await bulk_get_info(BulkRequest(cve_ids=chunk))
+        if isinstance(chunk_result, JSONResponse):
+            break  # DB error — return what we have
+        all_results.update(chunk_result)
+
+    return {"retried": len(error_ids), "results": all_results}
 
 
 @v1.get("/all_results", tags=["Results"], summary="Get all cached CVE results", response_model=AllResultsResponse)
@@ -383,12 +479,20 @@ async def all_results(
     offset: Annotated[int, Query(ge=0, description="Number of results to skip")] = 0,
     limit: Annotated[int, Query(ge=1, le=1000, description="Max results to return")] = 100,
 ):
-    """ Return cached CVE entries with full raw data (without priorities). Supports pagination via offset/limit. """
+    """
+    Return cached CVE entries with full raw data (without priorities). Supports pagination via offset/limit.
+    Error records (CVEs that failed to fetch) are automatically excluded from this response.
+    """
     try:
         async with aiosqlite.connect(DB_PATH) as db:
-            async with db.execute("SELECT COUNT(*) FROM results") as cursor:
+            async with db.execute(
+                "SELECT COUNT(*) FROM results WHERE json_extract(data, '$.__error__') IS NULL"
+            ) as cursor:
                 total = (await cursor.fetchone())[0]
-            async with db.execute("SELECT cve_id, data FROM results LIMIT ? OFFSET ?", (limit, offset)) as cursor:
+            async with db.execute(
+                "SELECT cve_id, data FROM results WHERE json_extract(data, '$.__error__') IS NULL LIMIT ? OFFSET ?",
+                (limit, offset),
+            ) as cursor:
                 rows = await cursor.fetchall()
     except aiosqlite.Error as e:
         logger.error("DB error fetching all results: %s", e)

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -519,15 +519,18 @@ async def test_bulk_too_many_cves(client):
 
 
 @pytest.mark.asyncio
-async def test_bulk_invalid_json_from_vulnx(client):
+async def test_bulk_invalid_json_from_vulnx(client, monkeypatch):
+    monkeypatch.setattr(main, "vulnx_retry_count", 1)
     m = MagicMock()
     m.returncode = 0
     m.stderr = b""
     m.stdout = b"not-json"
     with patch("main.subprocess.run", return_value=m):
         r = await client.post("/v1/cve", json={"cve_ids": [CVE_ID]})
-    assert r.status_code == 502
-    assert "error" in r.json()
+    assert r.status_code == 200
+    body = r.json()
+    assert CVE_ID in body
+    assert "error" in body[CVE_ID]
 
 
 @pytest.mark.asyncio
@@ -649,11 +652,15 @@ async def test_get_info_vulnx_timeout(client):
 
 
 @pytest.mark.asyncio
-async def test_bulk_vulnx_timeout(client):
+async def test_bulk_vulnx_timeout(client, monkeypatch):
+    monkeypatch.setattr(main, "vulnx_retry_count", 1)
     with patch("main.subprocess.run", side_effect=subprocess.TimeoutExpired(["vulnx"], 30)):
         r = await client.post("/v1/cve", json={"cve_ids": [CVE_ID]})
-    assert r.status_code == 504
-    assert "error" in r.json()
+    assert r.status_code == 200
+    body = r.json()
+    assert CVE_ID in body
+    assert "error" in body[CVE_ID]
+    assert "timed out" in body[CVE_ID]["error"]
 
 
 # --- vulnx auth / empty response ---
@@ -688,9 +695,107 @@ async def test_get_info_vulnx_empty_stdout(client):
 
 
 @pytest.mark.asyncio
-async def test_bulk_vulnx_auth_error(client):
+async def test_bulk_vulnx_auth_error(client, monkeypatch):
+    monkeypatch.setattr(main, "vulnx_retry_count", 1)
     with patch("main.subprocess.run", return_value=mock_vulnx_error(1, "Rate limit exceeded! API key required")):
         r = await client.post("/v1/cve", json={"cve_ids": [CVE_ID]})
-    assert r.status_code == 502
-    assert "vulnx error" in r.json()["error"]
-    assert "API key" in r.json()["error"]
+    assert r.status_code == 200
+    body = r.json()
+    assert CVE_ID in body
+    assert "error" in body[CVE_ID]
+    assert "vulnx error" in body[CVE_ID]["error"]
+
+
+# --- Error records ---
+
+@pytest.mark.asyncio
+async def test_error_record_excluded_from_all_results(client, monkeypatch):
+    """ CVEs that failed to fetch are stored as error records and excluded from /all_results """
+    monkeypatch.setattr(main, "vulnx_retry_count", 1)
+    with patch("main.subprocess.run", return_value=mock_vulnx_error(1, "Rate limit exceeded")):
+        r = await client.post("/v1/cve", json={"cve_ids": [CVE_ID]})
+    assert r.status_code == 200
+    assert "error" in r.json()[CVE_ID]
+
+    r = await client.get("/v1/all_results")
+    assert r.json()["total"] == 0
+    assert CVE_ID not in r.json()["results"]
+
+
+@pytest.mark.asyncio
+async def test_error_record_retried_on_next_single_fetch(client, monkeypatch):
+    """ Error records are treated as cache miss — single GET re-fetches from vulnx """
+    monkeypatch.setattr(main, "vulnx_retry_count", 1)
+    with patch("main.subprocess.run", return_value=mock_vulnx_error(1, "Rate limit exceeded")):
+        await client.post("/v1/cve", json={"cve_ids": [CVE_ID]})
+
+    # Single-CVE fetch must call vulnx again (not serve the error from cache)
+    with patch("main.subprocess.run", return_value=mock_vulnx(cve_payload())) as mock_run:
+        r = await client.get(f"/v1/get_info/{CVE_ID}")
+    assert r.status_code == 200
+    assert r.json()["Priority"] == "High"
+    mock_run.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_error_record_retried_on_next_bulk_fetch(client, monkeypatch):
+    """ Error records are treated as cache miss — next bulk request re-fetches them """
+    monkeypatch.setattr(main, "vulnx_retry_count", 1)
+    with patch("main.subprocess.run", return_value=mock_vulnx_error(1, "Rate limit exceeded")):
+        await client.post("/v1/cve", json={"cve_ids": [CVE_ID]})
+
+    with patch("main.subprocess.run", return_value=mock_vulnx([cve_payload()])) as mock_run:
+        r = await client.post("/v1/cve", json={"cve_ids": [CVE_ID]})
+    assert r.status_code == 200
+    assert r.json()[CVE_ID]["Priority"] == "High"
+    mock_run.assert_called_once()
+
+
+# --- POST /v1/retry_errors ---
+
+@pytest.mark.asyncio
+async def test_retry_errors_no_errors(client):
+    """ retry_errors returns 0 retried when there are no error records """
+    r = await client.post("/v1/retry_errors")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["retried"] == 0
+    assert body["results"] == {}
+
+
+@pytest.mark.asyncio
+async def test_retry_errors_retries_and_succeeds(client, monkeypatch):
+    """ retry_errors re-fetches error records and returns fresh priority results """
+    monkeypatch.setattr(main, "vulnx_retry_count", 1)
+    with patch("main.subprocess.run", return_value=mock_vulnx_error(1, "Rate limit exceeded")):
+        await client.post("/v1/cve", json={"cve_ids": [CVE_ID]})
+
+    with patch("main.subprocess.run", return_value=mock_vulnx([cve_payload()])):
+        r = await client.post("/v1/retry_errors")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["retried"] == 1
+    assert CVE_ID in body["results"]
+    assert body["results"][CVE_ID]["Priority"] == "High"
+
+
+@pytest.mark.asyncio
+async def test_retry_errors_clears_error_records(client, monkeypatch):
+    """ After successful retry_errors, CVEs appear in /all_results as proper entries """
+    monkeypatch.setattr(main, "vulnx_retry_count", 1)
+    with patch("main.subprocess.run", return_value=mock_vulnx_error(1, "Rate limit exceeded")):
+        await client.post("/v1/cve", json={"cve_ids": [CVE_ID]})
+
+    with patch("main.subprocess.run", return_value=mock_vulnx([cve_payload()])):
+        await client.post("/v1/retry_errors")
+
+    r = await client.get("/v1/all_results")
+    assert r.json()["total"] == 1
+    assert CVE_ID in r.json()["results"]
+
+
+@pytest.mark.asyncio
+async def test_retry_errors_response_shape(client):
+    r = await client.post("/v1/retry_errors")
+    assert r.status_code == 200
+    assert set(r.json().keys()) == {"retried", "results"}


### PR DESCRIPTION
- Add _fetch_batch_with_retry() helper: configurable total attempts (VULNX_RETRY_COUNT, default 3) with delay between retries (VULNX_RETRY_DELAY, default 5s)
- Persist failed CVEs as error records {"__error__": true, "message": "..."} in SQLite instead of returning 502 for the whole bulk request
- Bulk endpoint now returns per-CVE {"error": "..."} on batch failure, keeping successful results intact
- Error records are treated as cache miss on next single or bulk fetch
- Filter error records from GET /v1/all_results (count and rows)
- Add POST /v1/retry_errors: finds all error records, deletes them, re-fetches from vulnx, returns {"retried": N, "results": {...}}
- Error records expire with the same CACHE_TTL_HOURS as regular entries
- Update tests: bulk error cases now expect 200 + per-CVE error; add 7 new tests covering error persistence, exclusion, and retry_errors
- Document VULNX_RETRY_COUNT, VULNX_RETRY_DELAY, transient failure note, and use case #7 in README